### PR TITLE
Remove a try-except statement on reply()

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,10 +51,7 @@ class MyStreamListener(tweepy.StreamListener):
           my_reply = "@{0} Your search - {1} - did not match any tweets. Try \
                      different keywords.".format(tweet_username, query)
 
-          res = reply(twi_api=api, in_reply_to_status_id=tweet_id,
-                      status=my_reply)
-          if res == "Error":
-            raise Exception("Failed to tweet.")
+          reply(twi_api=api, in_reply_to_status_id=tweet_id, status=my_reply)
           return
 
         stop_words = ['てる', 'いる', 'なる', 'れる', 'する', 'ある',
@@ -112,20 +109,15 @@ class MyStreamListener(tweepy.StreamListener):
         my_reply = '@{0} Search results for "{1}" (about {2} tweets)'.format(
             tweet_username, query, str(len(searched_tweets)))  # Test
 
-        res = reply(twi_api=api, in_reply_to_status_id=tweet_id,
-                    status=my_reply, filename=file_path)
-        if res == "Error":
-          raise Exception("Failed to tweet.")
+        reply(twi_api=api, in_reply_to_status_id=tweet_id, status=my_reply,
+              filename=file_path)
 
       except Exception as e:
         LOGGER.error("[line %s] %s", sys.exc_info()[-1].tb_lineno, e)
 
         my_reply = "@{0} 500 Internal Server Error. Sorry, something went wrong.".format(tweet_username)
 
-        res = reply(twi_api=api, in_reply_to_status_id=tweet_id,
-                    status=my_reply)
-        if res == "Error":
-          raise Exception("Failed to tweet.")
+        reply(twi_api=api, in_reply_to_status_id=tweet_id, status=my_reply)
 
     return
 
@@ -231,32 +223,25 @@ def reply(twi_api, in_reply_to_status_id, status, filename=None):
     is in reply to (required)
   :param str status: The text of your status update (required)
   :param str filename: The local path to image file to upload (optional)
-  :returns: "Error" if something goes wrong, otherwise None
-  :rtype: str or None
 
   :Example:
 
   >>> reply(twi_api=api, in_reply_to_status_id=in_reply_to_status_id,
             status="text")
   """
-  try:
-    # Reply with text
-    if filename is None:
-      twi_api.update_status(in_reply_to_status_id=in_reply_to_status_id,
-                            status=status)
-      LOGGER.info('-> Tweeted "%s"', status)
+  # Reply with text
+  if filename is None:
+    twi_api.update_status(in_reply_to_status_id=in_reply_to_status_id,
+                          status=status)
+    LOGGER.info('-> Tweeted "%s"', status)
 
-    # Reply with both text and an image
-    else:
-      twi_api.update_with_media(in_reply_to_status_id=in_reply_to_status_id,
-                                status=status, filename=filename)
-      LOGGER.info('-> Tweeted "%s"', status)
+  # Reply with both text and an image
+  else:
+    twi_api.update_with_media(in_reply_to_status_id=in_reply_to_status_id,
+                              status=status, filename=filename)
+    LOGGER.info('-> Tweeted "%s"', status)
 
-    return
-
-  except Exception as e:
-    LOGGER.error("[line %s] %s", sys.exc_info()[-1].tb_lineno, e)
-    return "Error"
+  return
 
 
 if IS_TRAVIS_CI is True:


### PR DESCRIPTION
The statement is unnecessary because errors are already handled by [`try`][try] and [`except`][except].

[try]:https://github.com/cygnan/twitter-wordcloud-bot/blob/5b9e6beb9dd4bbdb7b67e4d5d60692c55f1278d4/main.py#L34
[except]:https://github.com/cygnan/twitter-wordcloud-bot/blob/5b9e6beb9dd4bbdb7b67e4d5d60692c55f1278d4/main.py#L115