### PR TITLE
Fix an issue where api.me().screen_name fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -354,7 +354,8 @@ def main():
     LOGGER.info(u"Hello @%s!", my_twitter_username)
 
     try:
-        my_stream = tweepy.Stream(auth=api.auth, listener=MyStreamListener())
+        my_stream_listener = MyStreamListener(api=api)
+        my_stream = tweepy.Stream(auth=api.auth, listener=my_stream_listener)
 
         LOGGER.info(u"Started streaming...")
         my_stream.userstream()


### PR DESCRIPTION
It seems that tweepy.api.auth is None in on_status
I guess this issue is Tweepy's bug. 

```
2018-02-05T23:11:38.637593+00:00 heroku[worker.1]: State changed from crashed to starting
2018-02-05T23:11:49.034438+00:00 heroku[worker.1]: Starting process with command `python main.py`
2018-02-05T23:11:49.816734+00:00 heroku[worker.1]: State changed from starting to up
2018-02-05T23:11:52.133145+00:00 app[worker.1]: [main.py:351] Authentication successful.
2018-02-05T23:11:52.431883+00:00 app[worker.1]: [main.py:354] Hello @twiwordcloudbot!
2018-02-05T23:11:52.433132+00:00 app[worker.1]: [main.py:359] Started streaming...
2018-02-06T04:16:12.847106+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
2018-02-06T09:23:14.120466+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
2018-02-06T09:24:12.019937+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
2018-02-06T09:24:24.225235+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
2018-02-06T09:43:45.471270+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
2018-02-06T09:45:30.850145+00:00 app[worker.1]: [main.py:163] [line 138] 'NoneType' object has no attribute 'get_username'
```